### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project('coordinationz',
                 # 'b_sanitize=address',  # Enable AddressSanitizer
                 # 'b_lundef=false',
                 ],
-        version:'0.0.9',
+        version:'0.1.2',
         license:'MIT',
         )
 

--- a/source/coordinationz/__init__.py
+++ b/source/coordinationz/__init__.py
@@ -1,6 +1,6 @@
 """Python Package Template"""
 from __future__ import annotations
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from .config import config, load_config, reload_config, save_config
 


### PR DESCRIPTION
This pull request updates the package version for `coordinationz` to `0.1.2` in both the build configuration and the Python package metadata.

Version updates:

* Updated the version in `meson.build` from `0.0.9` to `0.1.2` to reflect the latest release.
* Updated the `__version__` in `source/coordinationz/__init__.py` from `0.1.1` to `0.1.2` for consistency with the new release.