### PR TITLE
Bump version to 0.2.2 and update vertex weights type

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project('coordinationz',
                 # 'b_sanitize=address',  # Enable AddressSanitizer
                 # 'b_lundef=false',
                 ],
-        version:'0.2.1',
+        version:'0.2.2',
         license:'MIT',
         )
 

--- a/source/coordinationz/__init__.py
+++ b/source/coordinationz/__init__.py
@@ -1,6 +1,6 @@
 """Python Package Template"""
 from __future__ import annotations
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from .config import config, load_config, reload_config, save_config
 

--- a/source/fastcosine_core/cxnetwork/CVNetworkCentrality.c
+++ b/source/fastcosine_core/cxnetwork/CVNetworkCentrality.c
@@ -43,7 +43,7 @@ CVBool CVNetworkCalculateCentrality_weighted_parallel_implementation(const CVNet
 	
 	CVParallelForStart(centralityLoop, blockIndex, unrolledLoops){
 		
-		const CVDouble* verticesWeights = network->verticesWeights;
+		const CVFloat* verticesWeights = network->verticesWeights;
 		const CVBool* verticesEnabled = network->verticesEnabled;
 		
 		CVUIntegerArray* P = calloc(verticesCount, sizeof(CVUIntegerArray));
@@ -499,7 +499,7 @@ CVBool CVNetworkCalculateCentrality_implementation(const CVNetwork* network,CVDo
 		}
 	}
 	
-	const CVDouble* verticesWeights = network->verticesWeights;
+	const CVFloat* verticesWeights = network->verticesWeights;
 	const CVBool* verticesEnabled = network->verticesEnabled;
 	
 	CVDouble* centralityData = centrality->data;
@@ -696,7 +696,7 @@ CVBool CVNetworkCalculateStressCentrality_parallel_implementation(const CVNetwor
 	CVParallelForStart(centralityLoop, blockIndex, unrolledLoops){
 		
 		
-		const CVDouble* verticesWeights = network->verticesWeights;
+		const CVFloat* verticesWeights = network->verticesWeights;
 		const CVBool* verticesEnabled = network->verticesEnabled;
 		
 		CVUIntegerArray* P = calloc(verticesCount, sizeof(CVUIntegerArray));
@@ -826,7 +826,7 @@ CVBool CVNetworkCalculateStressCentrality_implementation(const CVNetwork* networ
 		}
 	}
 	
-	const CVDouble* verticesWeights = network->verticesWeights;
+	const CVFloat* verticesWeights = network->verticesWeights;
 	const CVBool* verticesEnabled = network->verticesEnabled;
 	
 	CVDouble* centralityData = centrality->data;

--- a/source/fastcosine_core/fastcosine_core.c
+++ b/source/fastcosine_core/fastcosine_core.c
@@ -191,9 +191,10 @@ static PyObject *cosine(PyObject *self, PyObject *args, PyObject *kwds) {
 	// lists are also supported
 	// Check if edgesObject is a numpy array
 	if (PyArray_Check(edgesObject)) {
+		PyArrayObject *edgesObjectArray = (PyArrayObject *)edgesObject;
 		// Check if the numpy array is of type int64 and contiguous
-		if (PyArray_TYPE(edgesObject) == NPY_INT64 && PyArray_IS_C_CONTIGUOUS(edgesObject)) {
-			edgesArray = (PyArrayObject *)edgesObject;
+		if (PyArray_TYPE(edgesObjectArray) == NPY_INT64 && PyArray_IS_C_CONTIGUOUS(edgesObjectArray)) {
+			edgesArray = edgesObjectArray;
 			Py_INCREF(edgesArray);
 			// printf("edgesArray is a numpy array of int64 and contiguous...\n");
 		} else {
@@ -216,9 +217,10 @@ static PyObject *cosine(PyObject *self, PyObject *args, PyObject *kwds) {
 	if(weightsObject!=NULL && weightsObject!=Py_None){
 		// convert weightsObject to numpy array of doubles if needed (will be readonly)
 		if (PyArray_Check(weightsObject)) {
+			PyArrayObject *weightsObjectArray = (PyArrayObject *)weightsObject;
 			// Check if the numpy array is of type double and contiguous
-			if (PyArray_TYPE(weightsObject) == NPY_FLOAT64 && PyArray_IS_C_CONTIGUOUS(weightsObject)) {
-				weightsArray = (PyArrayObject *)weightsObject;
+			if (PyArray_TYPE(weightsObjectArray) == NPY_FLOAT64 && PyArray_IS_C_CONTIGUOUS(weightsObjectArray)) {
+				weightsArray = weightsObjectArray;
 				Py_INCREF(weightsArray);
 				// printf("edgesArray is a numpy array of double and contiguous...\n");
 			} else {
@@ -258,9 +260,10 @@ static PyObject *cosine(PyObject *self, PyObject *args, PyObject *kwds) {
 
 	if (leftEdgesObject != NULL && leftEdgesObject != Py_None) {
 		if (PyArray_Check(leftEdgesObject)) {
+			PyArrayObject *leftEdgesObjectArray = (PyArrayObject *)leftEdgesObject;
 			// Check if the numpy array is of type int64 and contiguous
-			if (PyArray_TYPE(leftEdgesObject) == NPY_INT64 && PyArray_ISCONTIGUOUS(leftEdgesObject)) {
-				leftEdgesArray = (PyArrayObject *)leftEdgesObject;
+			if (PyArray_TYPE(leftEdgesObjectArray) == NPY_INT64 && PyArray_ISCONTIGUOUS(leftEdgesObjectArray)) {
+				leftEdgesArray = leftEdgesObjectArray;
 				Py_INCREF(leftEdgesArray);
 				// printf("leftEdgesArray is a numpy array of int64 and contiguous...\n");
 			} else {


### PR DESCRIPTION
This pull request primarily updates type consistency and improves clarity in the core C code and Python bindings, as well as bumping the package version. The most significant changes are grouped below:

**Type Consistency and Bug Fixes in C Core:**

* Changed the type of `verticesWeights` from `CVDouble*` to `CVFloat*` in several centrality calculation functions in `CVNetworkCentrality.c` to ensure consistency with the expected data type. [[1]](diffhunk://#diff-dd9606ae5f9f82919b17655cf5536f06d19849e2b6a445c068500221c73508b3L46-R46) [[2]](diffhunk://#diff-dd9606ae5f9f82919b17655cf5536f06d19849e2b6a445c068500221c73508b3L502-R502) [[3]](diffhunk://#diff-dd9606ae5f9f82919b17655cf5536f06d19849e2b6a445c068500221c73508b3L699-R699) [[4]](diffhunk://#diff-dd9606ae5f9f82919b17655cf5536f06d19849e2b6a445c068500221c73508b3L829-R829)

**Clarity and Safety Improvements in Python Bindings:**

* In `fastcosine_core.c`, introduced local `PyArrayObject*` variables to clarify casting and improve type safety when handling numpy arrays in the `cosine` function. This pattern is now used for `edgesObject`, `weightsObject`, and `leftEdgesObject`. [[1]](diffhunk://#diff-a9f0b77e479da80efb2f675fdcc1cae5e12042dd4558975275e1a58a809573c8R194-R197) [[2]](diffhunk://#diff-a9f0b77e479da80efb2f675fdcc1cae5e12042dd4558975275e1a58a809573c8R220-R223) [[3]](diffhunk://#diff-a9f0b77e479da80efb2f675fdcc1cae5e12042dd4558975275e1a58a809573c8R263-R266)

**Version Bump:**

* Updated the package version from `0.2.1` to `0.2.2` in both `meson.build` and `__init__.py` to reflect these changes. [[1]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L14-R14) [[2]](diffhunk://#diff-b5d455c9a338e03f7335a8c50a967a73125a4ef0d67bb5ae95ee761a9d6977eaL3-R3)